### PR TITLE
Allow building on Xcode 8

### DIFF
--- a/SelfSizingCollectionViewCells.xcodeproj/project.pbxproj
+++ b/SelfSizingCollectionViewCells.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 				TargetAttributes = {
 					42EAEACF19C9EBF600C2AEEC = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 					};
 					42EAEAE819C9EBF600C2AEEC = {
 						CreatedOnToolsVersion = 6.0;
@@ -380,6 +381,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SelfSizingCollectionViewCells/SelfSizingCollectionViewCells-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -394,6 +396,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.danielgalasko.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SelfSizingCollectionViewCells/SelfSizingCollectionViewCells-Bridging-Header.h";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
Hi there! I was looking through this repo recently and noticed that the app didn't build on Xcode 8. In order to do this, I've marked the current swift version as 2.3 to silence pesky "Convert to Current Swift Syntax" alerts. The app now builds on Xcode 8.
